### PR TITLE
Update LogitLib.jl

### DIFF
--- a/Logit/LogitLib.jl
+++ b/Logit/LogitLib.jl
@@ -9,7 +9,7 @@ end
 # each column is a vector of regressors, plus the 0/1 outcome in last row
 @views function logit(θ, n)
     k = size(θ,1)
-    data = randn(k+1,n)
+    data = [rand(1,n); randn(2,n); zeros(1,n)]
     data[k+1,:] = rand(1,n) .< 1.0 ./(1. .+ exp.(-θ'*data[1:k,:]))
     data
 end    


### PR DESCRIPTION
The original Logit dgp always generates samples with close to 50% 1, 50% zero. I believe that this is the reason that training sometimes gets stuck. This modification increases the dispersion, for some parameter draws, and in my trials,  training is not getting stuck.

If used, we need to update the Logit  MLE results, too. I can do that, if you like this PR.