### PR TITLE
Update train_transformer.jl

### DIFF
--- a/train_transformer.jl
+++ b/train_transformer.jl
@@ -82,10 +82,10 @@ function train_transformer(;
         err[:, :, i] = cpu(Ŷ - Y)
         rmse = sqrt.(mean(abs2.(err[:, :, i]), dims=2))
         model = cpu(model)
-        if validation_loss
+        if validation_loss && (mod(epoch, validation_frequency)==0 || epoch > epochs - 100)
             Flux.testmode!(best_model)
             Ŷb = StatsBase.reconstruct(dtY, best_model(X))
-            Ŷb = best_model(X)
+            # Ŷb = best_model(X)
             err_best[:, :, i] = cpu(Ŷb - Y)
             amae = mean(mean(abs.(err_best[:, :, i]), dims=2))
             armse = mean(sqrt.(mean(abs2.(err_best[:, :, i]), dims=2)))


### PR DESCRIPTION
I think that computing validation loss without transformation is an error, a hold-over from a mistaken commit.

Also, this computes validation only every so often, too speed up. At the end, it does it every epoch, to ensure that a good best model is found.